### PR TITLE
Fix or_else operations

### DIFF
--- a/include/Beman/Optional26/optional.hpp
+++ b/include/Beman/Optional26/optional.hpp
@@ -566,7 +566,7 @@ class optional {
 
     /// Calls `f` if the optional is empty
     template <class F>
-    constexpr optional<T> or_else(F&& f) & {
+    constexpr optional<T> or_else(F&& f) const & {
         if (has_value())
             return value_;
 
@@ -574,7 +574,7 @@ class optional {
     }
 
     template <class F>
-    optional<T> or_else(F&& f) && {
+    constexpr optional<T> or_else(F&& f) && {
         if (has_value())
             return std::move(value_);
 

--- a/src/Beman/Optional26/tests/optional.t.cpp
+++ b/src/Beman/Optional26/tests/optional.t.cpp
@@ -177,7 +177,10 @@ TEST(OptionalTest, AssignmentValue) {
 
     struct not_trivial_copy_assignable {
         int i_;
-        not_trivial_copy_assignable& operator=(const not_trivial_copy_assignable&);
+        not_trivial_copy_assignable& operator=(const not_trivial_copy_assignable& rhs) {
+            i_ = rhs.i_;
+            return *this;
+        }
     };
 
 

--- a/src/Beman/Optional26/tests/optional_monadic.t.cpp
+++ b/src/Beman/Optional26/tests/optional_monadic.t.cpp
@@ -299,4 +299,29 @@ TEST(OptionalMonadicTest, or_else) {
 
     beman::optional26::optional<int> o2;
     EXPECT_EQ(*(o2.or_else([] { return beman::optional26::make_optional(13); })), 13);
+
+    /*
+      optional<T> or_else(F&& f) && {
+    */
+    EXPECT_TRUE(*(std::move(o1).or_else([] { return beman::optional26::make_optional(13); })) == 42);
+    EXPECT_EQ(*(std::move(o2).or_else([] { return beman::optional26::make_optional(13); })), 13);
+
+}
+
+TEST(OptionalMonadicTest, Constexpr_or_else) {
+    constexpr beman::optional26::optional<int> o1 = 42;
+    constexpr auto test = (*(o1.or_else([] { return beman::optional26::make_optional(13); })) == 42);
+    EXPECT_TRUE(test);
+    constexpr beman::optional26::optional<int> o2;
+    constexpr auto test2 = *(o2.or_else([] { return beman::optional26::make_optional(13); })) == 13;
+    EXPECT_TRUE(test2);
+
+    /*
+      optional<T> or_else(F&& f) && {
+    */
+    constexpr auto test3 = (*(std::move(o1).or_else([] { return beman::optional26::make_optional(13); })) == 42);
+    EXPECT_TRUE(test3);
+    constexpr auto test4 = *(std::move(o2).or_else([] { return beman::optional26::make_optional(13); })) == 13;
+    EXPECT_TRUE(test4);
+
 }


### PR DESCRIPTION
missing const on one overload (unlike the other monadic ops) missing constexpr on && overload
Add tests to cover.