### PR TITLE
Apply 'Mandates' as static_asserts

### DIFF
--- a/src/Beman/Optional26/tests/optional_monadic.t.cpp
+++ b/src/Beman/Optional26/tests/optional_monadic.t.cpp
@@ -78,7 +78,7 @@ TEST(OptionalMonadicTest, Transform) {
 
     // callable which returns a reference
     beman::optional26::optional<int> o38  = 42;
-    auto                             o38r = o38.transform([](int& i) -> const int& { return i; });
+    beman::optional26::optional<const int&> o38r = o38.transform([](int& i) -> const int& { return i; });
     EXPECT_TRUE(o38r);
     EXPECT_TRUE(*o38r == 42);
 }


### PR DESCRIPTION
Change or add static_asserts to correspond to Mandates clauses. `requires` is the wrong mechanism.

Also weaken the constraint on `transform` as `is_object_v` rules out a U&, however optional<U&> is allowed in beman::optional.

Note to follow up change in paper wording.