### PR TITLE
Install by FILE_SET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,16 @@ include(FetchContent)
 
 set(TARGETS_EXPORT_NAME ${CMAKE_PROJECT_NAME}Targets)
 
-# Build the tests only if enabled via the CLI flag: BUILD_TESTING.
-if(BUILD_TESTING)
+option(OPTIONAL26_ENABLE_TESTING
+  "Enable building tests and test infrastructure"
+  ${PROJECT_IS_TOP_LEVEL})
+
+# Build the tests if enabled via the option OPTIONAL26_ENABLE_TESTING
+if(OPTIONAL26_ENABLE_TESTING)
     # Fetch GoogleTest
     FetchContent_Declare(
         googletest
+        EXCLUDE_FROM_ALL
         GIT_REPOSITORY https://github.com/google/googletest.git
         GIT_TAG
             e39786088138f2749d64e9e90e0f9902daa77c40 # release-1.15.0
@@ -24,39 +29,32 @@ if(BUILD_TESTING)
     FetchContent_MakeAvailable(googletest)
 endif()
 
+# Create the library target and named header set for beman_optional26
+add_library(beman_optional26 STATIC)
+target_sources(beman_optional26
+  PUBLIC
+  FILE_SET beman_optional26_headers TYPE HEADERS
+  BASE_DIRS
+  src
+  include
+)
+
+if(OPTIONAL26_ENABLE_TESTING)
+# Create the library target and named header set for testing beman_optional26
+# and mark the set private
+add_executable(beman_optional26_test)
+target_sources(beman_optional26_test
+  PRIVATE
+  FILE_SET beman_optional26_test_headers TYPE HEADERS
+  BASE_DIRS
+  src
+)
+endif()
+
 add_subdirectory(src/beman/optional26)
+add_subdirectory(include/beman/optional26)
+
 add_subdirectory(examples)
-
-include(GNUInstallDirs)
-
-set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake)
-
-install(
-    EXPORT ${TARGETS_EXPORT_NAME}
-    NAMESPACE ${CMAKE_PROJECT_NAME}
-    DESTINATION ${INSTALL_CONFIGDIR}
-)
-
-include(CMakePackageConfigHelpers)
-
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}ConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion
-)
-
-configure_package_config_file(
-    "cmake/Config.cmake.in"
-    ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake
-    INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
-)
-
-install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}Config.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}ConfigVersion.cmake
-    DESTINATION ${INSTALL_CONFIGDIR}
-)
 
 # Coverage
 configure_file("cmake/gcovr.cfg.in" gcovr.cfg @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,11 @@ include(FetchContent)
 
 set(TARGETS_EXPORT_NAME ${CMAKE_PROJECT_NAME}Targets)
 
-option(OPTIONAL26_ENABLE_TESTING
-  "Enable building tests and test infrastructure"
-  ${PROJECT_IS_TOP_LEVEL})
+option(
+    OPTIONAL26_ENABLE_TESTING
+    "Enable building tests and test infrastructure"
+    ${PROJECT_IS_TOP_LEVEL}
+)
 
 # Build the tests if enabled via the option OPTIONAL26_ENABLE_TESTING
 if(OPTIONAL26_ENABLE_TESTING)
@@ -31,24 +33,22 @@ endif()
 
 # Create the library target and named header set for beman_optional26
 add_library(beman_optional26 STATIC)
-target_sources(beman_optional26
-  PUBLIC
-  FILE_SET beman_optional26_headers TYPE HEADERS
-  BASE_DIRS
-  src
-  include
+target_sources(
+    beman_optional26
+    PUBLIC FILE_SET beman_optional26_headers TYPE HEADERS BASE_DIRS src include
 )
 
 if(OPTIONAL26_ENABLE_TESTING)
-# Create the library target and named header set for testing beman_optional26
-# and mark the set private
-add_executable(beman_optional26_test)
-target_sources(beman_optional26_test
-  PRIVATE
-  FILE_SET beman_optional26_test_headers TYPE HEADERS
-  BASE_DIRS
-  src
-)
+    # Create the library target and named header set for testing beman_optional26
+    # and mark the set private
+    add_executable(beman_optional26_test)
+    target_sources(
+        beman_optional26_test
+        PRIVATE
+            FILE_SET beman_optional26_test_headers
+            TYPE HEADERS
+            BASE_DIRS src
+    )
 endif()
 
 add_subdirectory(src/beman/optional26)

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ TARGET:=all
 compile: $(_build_path)/CMakeCache.txt ## Compile the project
 	cmake --build $(_build_path)  --config $(CONFIG) --target all -- -k 0
 
-install: $(_build_path)/CMakeCache.txt ## Install the project
-	DESTDIR=$(abspath $(DEST)) ninja -C $(_build_path) -k 0  install
+install: $(_build_path)/CMakeCache.txt compile ## Install the project
+	cmake --install $(_build_path) --config $(CONFIG) --component beman_optional26_development --verbose
 
 ctest: $(_build_path)/CMakeCache.txt ## Run CTest on current build
 	cd $(_build_path) && ctest --output-on-failure -C $(CONFIG)

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ This should build and run the tests with GCC 14 with the address and undefined b
 CI current build and test flows:
 
 ```shell
-# Configure build: default build production code + tests (BUILD_TESTING=ON by default).
+# Configure build: default build production code + tests (OPTIONAL26_ENABLE_TESTING=ON by default).
 $ cmake -G "Ninja Multi-Config" \
       -DCMAKE_CONFIGURATION_TYPES="RelWithDebInfo;Asan" \
       -DCMAKE_TOOLCHAIN_FILE=etc/clang-19-toolchain.cmake \
@@ -228,14 +228,14 @@ Total Test time (real) =   0.67 sec
 
 ##### Build Production, but Skip Tests
 
-By default, we build and run tests. You can provide `-DBUILD_TESTING=OFF` and completely disable building tests:
+By default, we build and run tests. You can provide `-DOPTIONAL26_ENABLE_TESTING=OFF` and completely disable building tests:
 
 ```shell
-# Configure build: build production code, skip tests (BUILD_TESTING=OFF).
+# Configure build: build production code, skip tests (OPTIONAL26_ENABLE_TESTING=OFF).
 $ cmake -G "Ninja Multi-Config" \
       -DCMAKE_CONFIGURATION_TYPES="RelWithDebInfo;Asan" \
       -DCMAKE_TOOLCHAIN_FILE=etc/clang-19-toolchain.cmake \
-      -DBUILD_TESTING=OFF \
+      -DOPTIONAL26_ENABLE_TESTING=OFF \
       -B .build -S .
 -- The CXX compiler identification is Clang 19.0.0
 ...

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach(example ${EXAMPLES})
     # Install .
     install(
         TARGETS ${example}
-        EXPORT ${TARGETS_EXPORT_NAME}
+        COMPONENT beman_optional26_examples
         DESTINATION
         ${CMAKE_INSTALL_BINDIR}
     )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,9 +29,11 @@ foreach(example ${EXAMPLES})
 
     # Install .
     install(
-        TARGETS ${example}
-        COMPONENT beman_optional26_examples
-        DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+        TARGETS
+            ${example}
+            COMPONENT
+            beman_optional26_examples
+            DESTINATION
+            ${CMAKE_INSTALL_BINDIR}
     )
 endforeach()

--- a/include/beman/optional26/CMakeLists.txt
+++ b/include/beman/optional26/CMakeLists.txt
@@ -1,0 +1,13 @@
+# include/beman/optional26/CMakeLists.txt -*-cmake-*-
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+target_sources(beman_optional26
+  PUBLIC
+  FILE_SET beman_optional26_headers TYPE HEADERS
+  FILES
+  optional.hpp
+  detail/iterator.hpp
+  detail/stl_interfaces/config.hpp
+  detail/stl_interfaces/fwd.hpp
+  detail/stl_interfaces/iterator_interface.hpp
+)

--- a/include/beman/optional26/CMakeLists.txt
+++ b/include/beman/optional26/CMakeLists.txt
@@ -1,13 +1,15 @@
 # include/beman/optional26/CMakeLists.txt -*-cmake-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-target_sources(beman_optional26
-  PUBLIC
-  FILE_SET beman_optional26_headers TYPE HEADERS
-  FILES
-  optional.hpp
-  detail/iterator.hpp
-  detail/stl_interfaces/config.hpp
-  detail/stl_interfaces/fwd.hpp
-  detail/stl_interfaces/iterator_interface.hpp
+target_sources(
+    beman_optional26
+    PUBLIC
+        FILE_SET beman_optional26_headers
+        TYPE HEADERS
+        FILES
+            optional.hpp
+            detail/iterator.hpp
+            detail/stl_interfaces/config.hpp
+            detail/stl_interfaces/fwd.hpp
+            detail/stl_interfaces/iterator_interface.hpp
 )

--- a/src/beman/optional26/CMakeLists.txt
+++ b/src/beman/optional26/CMakeLists.txt
@@ -2,22 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Ensure that optional and iterator get compiled at least once
-target_sources(beman_optional26
-  PUBLIC
-  optional.cpp
-  detail/iterator.cpp)
+target_sources(beman_optional26 PUBLIC optional.cpp detail/iterator.cpp)
 
 # The library is empty -- exclude it
-install(TARGETS beman_optional26
-  ARCHIVE
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT beman_optional26_library
-    EXCLUDE_FROM_ALL)
+install(
+    TARGETS beman_optional26
+    ARCHIVE
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT beman_optional26_library
+        EXCLUDE_FROM_ALL
+)
 
-install(TARGETS beman_optional26
-  FILE_SET beman_optional26_headers
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    COMPONENT beman_optional26_development)
+install(
+    TARGETS beman_optional26
+    FILE_SET beman_optional26_headers
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        COMPONENT beman_optional26_development
+)
 
 # Tests
 if(OPTIONAL26_ENABLE_TESTING)

--- a/src/beman/optional26/CMakeLists.txt
+++ b/src/beman/optional26/CMakeLists.txt
@@ -1,40 +1,25 @@
-# cmake-format: off
-# src/beman/optional26/CMakeLists.txt -*-makefile-*-
+# src/beman/optional26/CMakeLists.txt -*-cmake-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-# cmake-format: on
 
-add_library(beman_optional26 STATIC optional.cpp detail/iterator.cpp)
+# Ensure that optional and iterator get compiled at least once
+target_sources(beman_optional26
+  PUBLIC
+  optional.cpp
+  detail/iterator.cpp)
 
-include(GNUInstallDirs)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+# The library is empty -- exclude it
+install(TARGETS beman_optional26
+  ARCHIVE
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT beman_optional26_library
+    EXCLUDE_FROM_ALL)
 
-target_include_directories(
-    beman_optional26
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../src/>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_LOWER_PROJECT_NAME}>
-)
-
-install(
-    TARGETS beman_optional26
-    EXPORT ${TARGETS_EXPORT_NAME}
-    DESTINATION
-    ${CMAKE_INSTALL_LIBDIR}
-)
-
-string(TOLOWER ${CMAKE_PROJECT_NAME} CMAKE_LOWER_PROJECT_NAME)
-
-install(
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_LOWER_PROJECT_NAME}
-    FILES_MATCHING
-    PATTERN "*.hpp"
-)
-
-target_link_libraries(beman_optional26)
+install(TARGETS beman_optional26
+  FILE_SET beman_optional26_headers
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT beman_optional26_development)
 
 # Tests
-if(BUILD_TESTING)
+if(OPTIONAL26_ENABLE_TESTING)
     add_subdirectory(tests)
 endif()

--- a/src/beman/optional26/tests/CMakeLists.txt
+++ b/src/beman/optional26/tests/CMakeLists.txt
@@ -6,7 +6,7 @@
 include(GoogleTest)
 
 # Tests
-add_executable(beman_optional26_test)
+# add_executable(beman_optional26_test)
 
 target_sources(
     beman_optional26_test
@@ -19,6 +19,15 @@ target_sources(
         optional_ref_monadic.t.cpp
         test_types.cpp
         test_utilities.cpp
+)
+
+
+target_sources(beman_optional26_test
+  PRIVATE
+  FILE_SET beman_optional26_test_headers TYPE HEADERS
+  FILES
+  test_types.hpp
+  test_utilities.hpp
 )
 
 target_link_libraries(

--- a/src/beman/optional26/tests/CMakeLists.txt
+++ b/src/beman/optional26/tests/CMakeLists.txt
@@ -21,13 +21,12 @@ target_sources(
         test_utilities.cpp
 )
 
-
-target_sources(beman_optional26_test
-  PRIVATE
-  FILE_SET beman_optional26_test_headers TYPE HEADERS
-  FILES
-  test_types.hpp
-  test_utilities.hpp
+target_sources(
+    beman_optional26_test
+    PRIVATE
+        FILE_SET beman_optional26_test_headers
+        TYPE HEADERS
+        FILES test_types.hpp test_utilities.hpp
 )
 
 target_link_libraries(

--- a/src/beman/optional26/tests/test_constructor_fail.cpp
+++ b/src/beman/optional26/tests/test_constructor_fail.cpp
@@ -1,7 +1,7 @@
 // src/Beman/Optional26/tests/test_constructor_fail.t.cpp             -*-C++-*-
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <Beman/Optional26/optional.hpp>
+#include <beman/optional26/optional.hpp>
 #include <string>
 #include <utility>
 


### PR DESCRIPTION
Create named file sets and use those for installation. Exclude tests from installation, and the empty static library. Use a project prefixed name to enable or disable tests, and default to building tests if this is the top level project.